### PR TITLE
[Feat] 비로그인 alert 예외처리 추가, 연동 미션 관리

### DIFF
--- a/src/Page/BookDetail/components/BookDataPartition.tsx
+++ b/src/Page/BookDetail/components/BookDataPartition.tsx
@@ -10,6 +10,7 @@ import { useAssignMissions } from "@/api/useMissionsFetching";
 import { useAuthStore } from "@/store/useAuthStore";
 import tw from "@/utils/tw";
 import { showInfoAlert } from "@/Components/sweetAlert";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface Props {
   data: BookDetailData | undefined;
@@ -29,7 +30,12 @@ function BookDataPatition({
 
   const { mutate: toggleBookmark, isPending: togglePending } =
     useToggleBookmark(isbn13);
-  const { mutate: assignMission } = useAssignMissions(isbn13);
+  const qc = useQueryClient();
+  const { mutate: assignMission } = useAssignMissions(isbn13, {
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["missions", "book", isbn13] });
+    },
+  });
 
   // 서버단에서 북마크 정보 join해서 주는 게 낫나?
   const [isBookmarked, setIsBookmarked] = useState<boolean>();
@@ -61,7 +67,10 @@ function BookDataPatition({
 
   const handleClickAssignMission = () => {
     if (!isLogIn) {
-      showInfoAlert("로그인 필요", "미션을 수령하기 위해서는 로그인해야 합니다");
+      showInfoAlert(
+        "로그인 필요",
+        "미션을 수령하기 위해서는 로그인해야 합니다"
+      );
       return;
     }
     assignMission();

--- a/src/Page/BookDetail/components/BookDataPartition.tsx
+++ b/src/Page/BookDetail/components/BookDataPartition.tsx
@@ -52,11 +52,20 @@ function BookDataPatition({
 
   const handleToggleBookmark = () => {
     if (!isLogIn) {
-      showInfoAlert('로그인 필요', '북마크하기 위해서는 로그인해야 합니다')
+      showInfoAlert("로그인 필요", "북마크하기 위해서는 로그인해야 합니다");
       return;
     }
     toggleBookmark();
     setIsBookmarked((prev) => !prev);
+  };
+
+  const handleClickAssignMission = () => {
+    if (!isLogIn) {
+      showInfoAlert("로그인 필요", "미션을 수령하기 위해서는 로그인해야 합니다");
+      return;
+    }
+    assignMission();
+    setMissionAssigned(true);
   };
 
   if (!data) {
@@ -92,10 +101,7 @@ function BookDataPatition({
             "px-4 py-2 rounded-md text-xl bg-primary text-background-white absolute right-0 bottom-0",
             missionAssigned && "bg-gray-10 text-primary border border-primary"
           )}
-          onClick={() => {
-            assignMission();
-            setMissionAssigned(true);
-          }}
+          onClick={handleClickAssignMission}
           disabled={missionAssigned}
         >
           {missionAssigned ? "미션 수령 완료" : "미션 수령하기"}
@@ -128,7 +134,7 @@ function BookDataPatition({
             <span>장르 구분</span>
 
             {book.class_nm.split(" > ").map((item, index) => (
-              <span key={index} >{item}</span>
+              <span key={index}>{item}</span>
             ))}
           </p>
           <p>

--- a/src/Page/BookDetail/components/RelatedMissionsInfo.tsx
+++ b/src/Page/BookDetail/components/RelatedMissionsInfo.tsx
@@ -26,7 +26,7 @@ function RelatedMissionsInfo({ relatedMissions }: Props) {
                     key={m.template_id}
                     className="flex items-center justify-between rounded-lg bg-white px-3 py-2 ring-1 ring-amber-200"
                   >
-                    <span className="truncate text-sm font-medium text-amber-900">
+                    <span className="truncate text-sm font-medium text-amber-900 w-1/2">
                       {m.description}
                     </span>
                     {!m.assigned && (

--- a/src/Page/BookDetail/components/SummaryModal.tsx
+++ b/src/Page/BookDetail/components/SummaryModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import tw from "@/utils/tw";
 import logo from "/pickitbook_logo.svg";
 import type { MissionItemType } from "@/@types/global";
+import RelatedMissionsInfo from "./RelatedMissionsInfo";
 import type { UseMutateFunction } from "@tanstack/react-query";
 import type { SetSummaryType } from "@/api/summary.repo.supabase";
 
@@ -18,6 +19,7 @@ export default function SummaryModal({
   isOpen,
   onClose,
   onSave,
+  relatedMissions,
   bookTitle,
   isbn13,
 }: Props) {
@@ -119,6 +121,7 @@ export default function SummaryModal({
             </div>
           </div>
 
+          <RelatedMissionsInfo relatedMissions={relatedMissions} />
         </div>
 
         {/* Footer */}

--- a/src/Page/BookDetail/components/SummaryModal.tsx
+++ b/src/Page/BookDetail/components/SummaryModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import tw from "@/utils/tw";
 import logo from "/pickitbook_logo.svg";
 import type { MissionItemType } from "@/@types/global";
-import RelatedMissionsInfo from "./RelatedMissionsInfo";
 import type { UseMutateFunction } from "@tanstack/react-query";
 import type { SetSummaryType } from "@/api/summary.repo.supabase";
 
@@ -19,7 +18,6 @@ export default function SummaryModal({
   isOpen,
   onClose,
   onSave,
-  relatedMissions,
   bookTitle,
   isbn13,
 }: Props) {
@@ -121,7 +119,6 @@ export default function SummaryModal({
             </div>
           </div>
 
-          <RelatedMissionsInfo relatedMissions={relatedMissions} />
         </div>
 
         {/* Footer */}

--- a/src/Page/BookDetail/index.tsx
+++ b/src/Page/BookDetail/index.tsx
@@ -91,7 +91,7 @@ function BookDetail() {
         </PartitionBase>
 
         <PartitionBase title="리뷰 작성">
-          <ReviewWritePartition data={BookDetailData} />
+          <ReviewWritePartition missions={missionData} data={BookDetailData} />
         </PartitionBase>
 
         <PartitionBase

--- a/src/Page/BookDetail/index.tsx
+++ b/src/Page/BookDetail/index.tsx
@@ -24,9 +24,7 @@ function BookDetail() {
   }, []);
 
   // BookDetail 정보 불러오기
-  const {
-    data: BookDetailData,
-  } = useBookDetail(isbn13);
+  const { data: BookDetailData } = useBookDetail(isbn13);
 
   // Review 정보 불러오기
   const { data: reviewData } = useGetReview(isbn13);
@@ -50,9 +48,13 @@ function BookDetail() {
       : Math.ceil((summary / reviewData?.length) * 10) / 10;
   }, [reviewData]);
 
+  const isMissionAssigned = useMemo(() => {
+    return missionData?.[0].assigned;
+  }, [missionData]);
+
   const reviewSize = useMemo(() => {
-    return reviewData?.length
-  }, [reviewData])
+    return reviewData?.length;
+  }, [reviewData]);
 
   return (
     <div className="flex justify-center w-full bg-pattern">
@@ -62,7 +64,7 @@ function BookDetail() {
         <PartitionBase title="도서 정보">
           <BookDataPartition
             data={BookDetailData}
-            isMissionAssigned={missionData?.[0].assigned}
+            isMissionAssigned={isMissionAssigned}
             ratingAvg={ratingAvg}
             reviewSize={reviewSize}
           />
@@ -83,11 +85,11 @@ function BookDetail() {
         </PartitionBase>
 
         <PartitionBase title="유저 평점">
-          <UserScorePatition data={reviewData} ratingAvg={ratingAvg}/>
+          <UserScorePatition data={reviewData} ratingAvg={ratingAvg} />
         </PartitionBase>
 
         <PartitionBase title="3줄 요약">
-          <SummaryPartition missions={missionData} isbn13={isbn13}/>
+          <SummaryPartition missions={missionData} isbn13={isbn13} />
         </PartitionBase>
 
         <PartitionBase title="리뷰 작성">

--- a/src/api/useMissionsFetching.ts
+++ b/src/api/useMissionsFetching.ts
@@ -1,8 +1,11 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
 import { missionsRepo } from "./missions.repo.supabase";
 import type { MissionItemType } from "@/@types/global";
 import { logicRpcRepo } from "./logicRpc.repo.supabase";
-
 
 type UseMissionsFetchingOptions = {
   enabled?: boolean;
@@ -35,7 +38,10 @@ export const useGetMissionByISBN = (
 };
 
 // 해당 isbn에 대한 미션들을 로그인한 유저에게 수락 처리합니다.
-export const useAssignMissions = (isbn13: string | undefined) => {
+export const useAssignMissions = (
+  isbn13: string | undefined,
+  options?: UseMutationOptions<unknown, Error, void>
+) => {
   return useMutation({
     mutationKey: ["missionAssign", isbn13],
     mutationFn: async () => {
@@ -43,5 +49,6 @@ export const useAssignMissions = (isbn13: string | undefined) => {
       return await logicRpcRepo.setBundle(isbn13);
     },
     retry: 0,
+    ...options
   });
 };


### PR DESCRIPTION
## 작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
비로그인 alert 예외처리 추가, 연동 미션 관리

## 작업 내용
- [x] 비로그인 alert 예외처리 추가
- [x] 연동 미션 목록을 버튼 형식으로 펼쳐보도록 변경
- [x] 미션을 수령했을 때 수령 여부를 즉시 판별하도록 query 변경 

## 관련 이슈

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->
연동 미션 기능도 잘 작동하고 미션 받았을 때 즉시 미션 수령 여부를 잘 판별하는 것 같습니다! 추가 이슈 있으면 알려주세요